### PR TITLE
Use symlinks over default-tiddler-location

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -75,6 +75,17 @@ module.exports = yeoman.generators.Base.extend({
       );
     },
 
+    // TiddlyWiki considers tiddlers in config.default-tiddler-location as
+    // readonly and will produce sequential new files which causes havok with
+    // git stagging. SymLinks however work like a normal tiddler folder but
+    // allow both editions to work on the same tiddler folder.
+    symlinks: function () {
+      ['wiki/tiddlers', 'wiki-dist/tiddlers'].forEach(function(p) {
+        var dest = this.destinationPath(p);
+        fs.symlinkSync('../tiddlers', dest, 'dir');
+      }, this);
+    },
+
     projectfiles: function () {
       this.fs.copy(
         this.templatePath('_gitignore'),

--- a/generators/app/templates/wiki/tiddlywiki.info
+++ b/generators/app/templates/wiki/tiddlywiki.info
@@ -8,8 +8,5 @@
     "themes": [
         "tiddlywiki/vanilla",
         "tiddlywiki/snowwhite"
-    ],
-    "config": {
-        "default-tiddler-location": "../wiki-dist/tiddlers"
-    }
+    ]
 }


### PR DESCRIPTION
I noticed that when using `tiddlywiki wiki --server` that instead of tiddlers being modified when saving changes it started creating sequentially numbered versions of the tiddlers.

For example after running the server and opening the page in the browser I immediately had a new file added called `wiki-dist/tiddlers/$__StoryList 1.tid`. Then if I stop and restarted the server I'd end up with yet another additional file: `wiki-dist/tiddlers/$__StoryList 2.tid`.

I guessed this was an artifact of using the `config.default-tiddler-location` instead. It is too bad but it seems the only way to have multiple additions share the same `tiddlers` folder is to us symbolic links.
